### PR TITLE
Added support for colon (:) in design document id

### DIFF
--- a/couchdb-external-hook.py
+++ b/couchdb-external-hook.py
@@ -61,7 +61,7 @@ def respond(res, req, key):
 
     # URL-escape each part
     for index, item in enumerate(path):
-        path[index] = urllib.quote(path[index], "")
+        path[index] = urllib.quote(path[index], safe=":/")
 
     path = '/'.join(['', key] + path)
     params = urllib.urlencode(dict([k, v.encode('utf-8')] for k, v in req["query"].items()))


### PR DESCRIPTION
I added support for having colons in the design document id which CouchDB supports. 

The change ensures that the colon is not url encoded in the python file. 
