### PR TITLE
setAllowLeadingWildcard

### DIFF
--- a/src/main/java/com/github/rnewson/couchdb/lucene/CustomQueryParser.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/CustomQueryParser.java
@@ -16,6 +16,8 @@ package com.github.rnewson.couchdb.lucene;
  * limitations under the License.
  */
 
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.HierarchicalINIConfiguration;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryParser.ParseException;
 import org.apache.lucene.queryParser.QueryParser;
@@ -27,7 +29,9 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.github.rnewson.couchdb.lucene.Config;
 import com.github.rnewson.couchdb.lucene.couchdb.FieldType;
+
 
 /**
  * Custom query parser that uses NumericFieldQuery where appropriate.
@@ -37,8 +41,12 @@ import com.github.rnewson.couchdb.lucene.couchdb.FieldType;
  */
 public final class CustomQueryParser extends QueryParser {
 
-    public CustomQueryParser(final Version matchVersion, final String f, final Analyzer a) {
+    public CustomQueryParser (final Version matchVersion, final String f, final Analyzer a) throws ConfigurationException {
         super(matchVersion, f, a);
+	// Allow users to set setAllowLeasingWildcard true
+	HierarchicalINIConfiguration ini = new Config().getConfiguration();
+	boolean allowLeadingWildcard = ini.getBoolean("lucene.setAllowLeadingWildcard", false);
+	this.setAllowLeadingWildcard(allowLeadingWildcard);
     }
 
 	public static Sort toSort(final String sort) throws ParseException {

--- a/src/main/resources/couchdb-lucene.ini
+++ b/src/main/resources/couchdb-lucene.ini
@@ -1,20 +1,23 @@
 [lucene]
-# The output directory for Lucene indexes.
+; The output directory for Lucene indexes.
 dir=indexes
 
-# The local host name that couchdb-lucene binds to
+; The local host name that couchdb-lucene binds to
 host=localhost
 
-# The port that couchdb-lucene binds to.
+; The port that couchdb-lucene binds to.
 port=5985
 
-# Timeout for requests in milliseconds.
+; Timeout for requests in milliseconds.
 timeout=10000
 
-# Default limit for search results
+; Default limit for search results
 limit=25
 
-# couchdb server mappings
+;disallow wildcards
+setAllowLeadingWildcard=false
+
+; couchdb server mappings
 
 [local]
 url = http://localhost:5984/


### PR DESCRIPTION
patch includes invoking a hierarchical ini thingie in the query parser, which defaults to false (the config file default is also surprisingly false) for the setAllowLeadingWildcard option in lucene. Also changed the config files comment from unix shell style to a more appropriate ini-file style
