### PR TITLE
Strip of context path, so C-L can be deployed under different contexts

### DIFF
--- a/src/main/java/com/github/rnewson/couchdb/lucene/LuceneServlet.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/LuceneServlet.java
@@ -47,6 +47,8 @@ import com.github.rnewson.couchdb.lucene.couchdb.DesignDocument;
 import com.github.rnewson.couchdb.lucene.couchdb.View;
 import com.github.rnewson.couchdb.lucene.util.ServletUtils;
 
+import static com.github.rnewson.couchdb.lucene.util.ServletUtils.getUri;
+
 public final class LuceneServlet extends HttpServlet {
 
 	private static final Logger LOG = Logger.getLogger(LuceneServlet.class);
@@ -181,7 +183,7 @@ public final class LuceneServlet extends HttpServlet {
 
     private void doGetInternal(final HttpServletRequest req, final HttpServletResponse resp)
             throws ServletException, IOException, JSONException {
-        switch (StringUtils.countMatches(req.getRequestURI(), "/")) {
+        switch (StringUtils.countMatches(getUri(req), "/")) {
 		case 1:
 			handleWelcomeReq(req, resp);
 			return;
@@ -216,9 +218,9 @@ public final class LuceneServlet extends HttpServlet {
 
     private void doPostInternal(final HttpServletRequest req, final HttpServletResponse resp)
             throws IOException, JSONException {
-        switch (StringUtils.countMatches(req.getRequestURI(), "/")) {
+        switch (StringUtils.countMatches(getUri(req), "/")) {
 		case 3:
-			if (req.getPathInfo().endsWith("/_cleanup")) {
+			if (req.getRequestURI().endsWith("/_cleanup")) {
 				cleanup(req, resp);
 				return;
 			}
@@ -230,5 +232,6 @@ public final class LuceneServlet extends HttpServlet {
 		}
 		ServletUtils.sendJsonError(req, resp, 400, "bad_request");
     }
+
 
 }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/PathParts.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/PathParts.java
@@ -5,6 +5,8 @@ import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 
+import static com.github.rnewson.couchdb.lucene.util.ServletUtils.getUri;
+
 public class PathParts {
 
 	private static final Pattern QUERY_REGEX = Pattern
@@ -16,7 +18,7 @@ public class PathParts {
 	private Matcher matcher;
 
 	public PathParts(final HttpServletRequest req) {
-		this(req.getRequestURI());
+		this(getUri(req));
 	}
 
 	public PathParts(final String path) {

--- a/src/main/java/com/github/rnewson/couchdb/lucene/util/ServletUtils.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/util/ServletUtils.java
@@ -103,4 +103,10 @@ public final class ServletUtils {
         }
     }
 
+   //Strip of context part of URI
+   public static String getUri(HttpServletRequest request) {
+       //Strip of context path if present
+       return request.getRequestURI().substring(request.getContextPath().length());
+   }
+
 }


### PR DESCRIPTION
This patch strips of the contextPath when examining URIs, so LuceneServlet can be deployed under any context, and not just "/".
