### PR TITLE
Specify configuration file in servlet init-parameters

### DIFF
--- a/src/main/java/com/github/rnewson/couchdb/lucene/Config.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/Config.java
@@ -3,6 +3,7 @@ package com.github.rnewson.couchdb.lucene;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URL;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalINIConfiguration;
@@ -21,8 +22,11 @@ public final class Config {
     private final HierarchicalINIConfiguration configuration;
 
     public Config() throws ConfigurationException {
-        this.configuration = new HierarchicalINIConfiguration(Config.class
-                .getClassLoader().getResource(CONFIG_FILE));
+        this(Config.class.getClassLoader().getResource(CONFIG_FILE));
+    }
+
+    public Config(URL file) throws ConfigurationException {
+        this.configuration = new HierarchicalINIConfiguration(file);
         this.configuration
                 .setReloadingStrategy(new FileChangedReloadingStrategy());
     }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/HttpClientFactory.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/HttpClientFactory.java
@@ -177,6 +177,7 @@ public final class HttpClientFactory {
     }
 
     public static void setIni(final HierarchicalINIConfiguration ini) {
+        instance = null;
         INI = ini;
     }
 

--- a/src/main/java/com/github/rnewson/couchdb/lucene/LuceneServlet.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/LuceneServlet.java
@@ -19,6 +19,7 @@ package com.github.rnewson.couchdb.lucene;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -84,12 +85,17 @@ public final class LuceneServlet extends HttpServlet {
 	    try {
 	        if (configFile != null) {
 	            final URL url = new URL(configFile);
+	            InputStream ignoredStream = null;
 	            try {
-	                url.openStream(); //Check that file actually exists
+	                ignoredStream = url.openStream(); //Check that file actually exists
 	                init(new Config(url));
 	            } catch (FileNotFoundException e ) {
 	                LOG.error("Cannot open: " + configFile + ". Using defaults");
 	                init(new Config());
+	            } finally {
+	                if (ignoredStream != null) {
+	                    ignoredStream.close();
+	                }
 	            }
 	        } else {
 	            init(new Config());

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -9,6 +9,11 @@
   <servlet>
     <servlet-name>lucene</servlet-name>
     <servlet-class>com.github.rnewson.couchdb.lucene.LuceneServlet</servlet-class>
+    <init-param>
+      <description>CouchDB-Lucene configuration file URL</description>
+      <param-name>config</param-name>
+      <param-value>file:///etc/couchdb-lucene/couchdb-lucene.ini</param-value>
+    </init-param>
   </servlet>
 
   <servlet-mapping>


### PR DESCRIPTION
This patch allows one to specify the configuration file to use when C-L is running in a servlet-container.
