### PR TITLE
allow c-l to run in custom servlet context path

### DIFF
--- a/src/main/java/com/github/rnewson/couchdb/lucene/LuceneServlet.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/LuceneServlet.java
@@ -122,7 +122,7 @@ public final class LuceneServlet extends HttpServlet {
 	}
 
 	private Couch getCouch(final HttpServletRequest req) throws IOException {
-		final String sectionName = new PathParts(req).getKey();
+		final String sectionName = new PathParts(PathParts.getPathWithoutContext(req)).getKey();
 		final Configuration section = ini.getSection(sectionName);
 		if (!section.containsKey("url")) {
 			throw new FileNotFoundException(sectionName + " is missing or has no url parameter.");
@@ -153,8 +153,7 @@ public final class LuceneServlet extends HttpServlet {
 	private DatabaseIndexer getIndexer(final HttpServletRequest req)
 			throws IOException, JSONException {
 		final Couch couch = getCouch(req);
-		final Database database = couch.getDatabase(new PathParts(req)
-				.getDatabaseName());
+		final Database database = couch.getDatabase(new PathParts(PathParts.getPathWithoutContext(req)).getDatabaseName());
 		return getIndexer(database);
 	}
 
@@ -179,9 +178,9 @@ public final class LuceneServlet extends HttpServlet {
         }
 	}
 
-    private void doGetInternal(final HttpServletRequest req, final HttpServletResponse resp)
-            throws ServletException, IOException, JSONException {
-        switch (StringUtils.countMatches(req.getRequestURI(), "/")) {
+	private void doGetInternal(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException, JSONException {
+		LOG.debug("processing path "+req.getRequestURI()+" -- effective: "+PathParts.getPathWithoutContext(req));
+		switch (StringUtils.countMatches(PathParts.getPathWithoutContext(req), "/")) {
 		case 1:
 			handleWelcomeReq(req, resp);
 			return;
@@ -214,9 +213,8 @@ public final class LuceneServlet extends HttpServlet {
         }
 	}
 
-    private void doPostInternal(final HttpServletRequest req, final HttpServletResponse resp)
-            throws IOException, JSONException {
-        switch (StringUtils.countMatches(req.getRequestURI(), "/")) {
+	private void doPostInternal(final HttpServletRequest req, final HttpServletResponse resp) throws IOException, JSONException {
+		switch (StringUtils.countMatches(PathParts.getPathWithoutContext(req), "/")) {
 		case 3:
 			if (req.getPathInfo().endsWith("/_cleanup")) {
 				cleanup(req, resp);

--- a/src/main/java/com/github/rnewson/couchdb/lucene/PathParts.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/PathParts.java
@@ -15,11 +15,11 @@ public class PathParts {
 
 	private Matcher matcher;
 
-	public PathParts(final HttpServletRequest req) {
-		this(req.getRequestURI());
+	public PathParts(final String path) {
+		this.setPath(path);
 	}
 
-	public PathParts(final String path) {
+	public void setPath(String path) {
 		matcher = QUERY_REGEX.matcher(path);
 		if (!matcher.matches()) {
 			matcher = GLOBAL_REGEX.matcher(path);
@@ -61,4 +61,12 @@ public class PathParts {
 				+ "]";
 	}
 
+	public static String getPathWithoutContext(HttpServletRequest request) {
+		if (request.getContextPath().isEmpty() && (!("/".equals(request.getContextPath())))) {
+			return request.getRequestURI();
+		} else {
+			return (request.getRequestURI().replace(request.getContextPath(), ""));
+		}
+
+	}
 }

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -21,7 +21,7 @@
   </appender>
 
   <logger name="com.github">
-    <level value="INFO"/>
+    <level value="DEBUG"/>
   </logger>
 
   <root>


### PR DESCRIPTION
The change is pretty much similar to the one suggested by jalpedersen, differs just in details. Having the context replacement done in the static method on PathParts seems not the nicest way of doing this, though; I'd prefer refactoring all the javax.servlet dependencies out of PathParts... 
