### PR TITLE
pom.xml: set encoding of Maven to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,7 @@
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
I was getting...

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:testCompile (default-testCompile) on project couchdb-lucene: Compilation failure: Compilation failure:
[ERROR] /home/dyu/src/couchdb-lucene/src/test/java/com/github/rnewson/couchdb/lucene/CustomQueryParserTest.java:[103,40] error: unmappable character for encoding ASCII
[ERROR] /home/dyu/src/couchdb-lucene/src/test/java/com/github/rnewson/couchdb/lucene/CustomQueryParserTest.java:[103,41] error: unmappable character for encoding ASCII
```
