### PR TITLE
squid:S2325 - private methods that don't access instance data should be static

### DIFF
--- a/src/main/java/com/github/rnewson/couchdb/lucene/DatabaseIndexer.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/DatabaseIndexer.java
@@ -718,12 +718,12 @@ public final class DatabaseIndexer implements Runnable, ResponseHandler<Void> {
         lastCommit = now();
     }
 
-    private boolean getBooleanParameter(final HttpServletRequest req,
+    private static boolean getBooleanParameter(final HttpServletRequest req,
                                         final String parameterName) {
         return Boolean.parseBoolean(req.getParameter(parameterName));
     }
 
-    private int getIntParameter(final HttpServletRequest req,
+    private static int getIntParameter(final HttpServletRequest req,
                                 final String parameterName, final int defaultValue) {
         final String result = req.getParameter(parameterName);
         return result != null ? Integer.parseInt(result) : defaultValue;
@@ -811,7 +811,7 @@ public final class DatabaseIndexer implements Runnable, ResponseHandler<Void> {
         latch.countDown();
     }
 
-    private boolean isStaleOk(final HttpServletRequest req) {
+    private static boolean isStaleOk(final HttpServletRequest req) {
         return "ok".equals(req.getParameter("stale"));
     }
 
@@ -852,7 +852,7 @@ public final class DatabaseIndexer implements Runnable, ResponseHandler<Void> {
         return toPath(parts.getDesignDocumentName(), parts.getViewName());
     }
 
-    private String toPath(final String ddoc, final String view) {
+    private static String toPath(final String ddoc, final String view) {
         return ddoc + "/" + view;
     }
 

--- a/src/main/java/com/github/rnewson/couchdb/lucene/couchdb/Database.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/couchdb/Database.java
@@ -170,7 +170,7 @@ public final class Database {
         return result;
     }
 
-    private List<JSONObject> rows(final JSONObject json) throws JSONException {
+    private static List<JSONObject> rows(final JSONObject json) throws JSONException {
         final List<JSONObject> result = new ArrayList<JSONObject>();
         final JSONArray rows = json.getJSONArray("rows");
         for (int i = 0; i < rows.length(); i++) {

--- a/src/main/java/com/github/rnewson/couchdb/lucene/couchdb/View.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/couchdb/View.java
@@ -94,7 +94,7 @@ public final class View {
         }
     }
 
-    private String trim(final String fun) {
+    private static String trim(final String fun) {
         String result = fun;
         result = StringUtils.trim(result);
         result = StringUtils.removeStart(result, "\"");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2325 - private methods that don't access instance data should be static.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
Please let me know if you have any questions.
George Kankava