### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/github/rnewson/couchdb/lucene/HttpClientFactory.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/HttpClientFactory.java
@@ -59,6 +59,10 @@ import java.util.concurrent.TimeUnit;
  */
 public final class HttpClientFactory {
 
+    private HttpClientFactory () {
+        throw new InstantiationError("This class is not supposed to be instantiated.");
+    }	
+
     private static final class PreemptiveAuthenticationRequestInterceptor
             implements HttpRequestInterceptor {
 

--- a/src/main/java/com/github/rnewson/couchdb/lucene/Main.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/Main.java
@@ -28,10 +28,13 @@ import javax.servlet.DispatcherType;
 import java.io.File;
 import java.util.EnumSet;
 
-public class Main {
+public final class Main {
 
     private static final Logger LOG = Logger.getLogger(Main.class);
 
+    private Main() {
+        throw new InstantiationError("This class is not supposed to be instantiated.");
+    }
     /**
      * Run couchdb-lucene.
      */

--- a/src/main/java/com/github/rnewson/couchdb/lucene/couchdb/HttpUtils.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/couchdb/HttpUtils.java
@@ -28,6 +28,9 @@ import java.io.IOException;
 
 public final class HttpUtils {
 
+    private HttpUtils() {
+        throw new InstantiationError("This class is not supposed to be instantiated.");
+    }
     public static final int delete(final HttpClient httpClient, final String url) throws IOException {
         return httpClient.execute(new HttpDelete(url), new StatusCodeResponseHandler());
     }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/util/Constants.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/util/Constants.java
@@ -22,6 +22,10 @@ import org.apache.lucene.util.Version;
 
 public final class Constants {
 
+    private Constants() {
+        throw new InstantiationError("This class is not supposed to be instantiated.");
+    }
+
     public static final Version VERSION = Version.LUCENE_4_10_2;
 
     public static final Analyzer ANALYZER = new StandardAnalyzer(VERSION);

--- a/src/main/java/com/github/rnewson/couchdb/lucene/util/ServletUtils.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/util/ServletUtils.java
@@ -27,6 +27,10 @@ import java.io.Writer;
 
 public final class ServletUtils {
 
+    private ServletUtils() {
+        throw new InstantiationError("This class is not supposed to be instantiated.");
+    }
+
     public static boolean getBooleanParameter(final HttpServletRequest req, final String parameterName) {
         return Boolean.parseBoolean(req.getParameter(parameterName));
     }

--- a/src/main/java/com/github/rnewson/couchdb/lucene/util/Utils.java
+++ b/src/main/java/com/github/rnewson/couchdb/lucene/util/Utils.java
@@ -26,7 +26,11 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
-public class Utils {
+public final class Utils {
+
+    private Utils() {
+        throw new InstantiationError("This class is not supposed to be instantiated.");
+    }
 
     public static Logger getLogger(final Class<?> clazz, final String suffix) {
         return Logger.getLogger(clazz.getCanonicalName() + "." + suffix);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
Please let me know if you have any questions.
George Kankava