### PR TITLE
Remove unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,6 @@
             <version>${http-version}</version>
         </dependency>
         <dependency>
-            <groupId>net.jcip</groupId>
-            <artifactId>jcip-annotations</artifactId>
-            <version>1.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <version>${jetty-version}</version>
@@ -48,11 +43,6 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>${jetty-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
             <version>${jetty-version}</version>
         </dependency>
         <dependency>
@@ -119,11 +109,6 @@
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers</artifactId>
             <version>${tika-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.poi</groupId>
-            <artifactId>ooxml-schemas</artifactId>
-            <version>1.1</version>
         </dependency>
         <dependency>
             <groupId>org.erlang.otp</groupId>


### PR DESCRIPTION
Hello. I noticed that dependencies `net.jcip:jcip-annotations`, `org.eclipse.jetty:jetty-servlets`, and `org.apache.poi:ooxml-schemas` are declared in the `pom` but not used. Hence, these dependencies can be safely removed to reduce the size of the library and also make the `pom` clearer.